### PR TITLE
Fix the properly place for custom systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CentOS 7 systemd (systemctl) file to use with stunnel
 
 Save file to:
 
-    /lib/systemd/system/stunnel.service
+    /etc/systemd/system/stunnel.service
 
 Use commands like:
 


### PR DESCRIPTION
Use a properly place for the custom system-wide systemd-unit on the CentOS 7